### PR TITLE
Add import/order rule

### DIFF
--- a/configs/es6.js
+++ b/configs/es6.js
@@ -40,6 +40,15 @@ module.exports = {
         // Restrict file extensions that may be required
         'import/extensions': [2, { 'js': 'never' }],
 
+        // Enforce convention in module import order
+        'import/order': [2, {
+            'groups': [
+                ['builtin', 'external'],
+                ['internal', 'parent', 'index', 'sibling']
+            ],
+            'newlines-between': 'always'
+        }],
+
         // Disallow modifying variables of class declarations
         'no-class-assign': 2,
 


### PR DESCRIPTION
Closes #11 

Note:
- To enable ESlint to differentiate between internal and external modules, the `eslint-import-resolver` for the resolver in use has to be installed and defined in the `.eslintrc`:

```json
{
  "settings": {
    "import/resolver": <Resolver-Config>
  }
}
```

This has been already done in https://github.com/infektweb/guidelines.v4/pull/1576.